### PR TITLE
added k6 load tests

### DIFF
--- a/k6/1-concurrentUsers.js
+++ b/k6/1-concurrentUsers.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+// tests for k6
+// 1. concurrent requests for API itself: how many requests can it handle?
+// 2. increasing block range: at what point will it break? --single user
+
+
+export default function () {
+    const params = {
+        headers: {
+            'x-api-key': 'abc',
+        },
+    };
+
+    http.get('http://localhost:8000/fetch_data?block_start=18530000&block_end=18530100', params);
+    sleep(1);
+}

--- a/k6/2-moreBlocks.js
+++ b/k6/2-moreBlocks.js
@@ -1,0 +1,13 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export default function () {
+    const params = {
+        headers: {
+            'x-api-key': 'abc',
+        },
+    };
+
+    http.get('http://localhost:8000/fetch_data?block_start=18530000&block_end=18531000', params);
+    sleep(1);
+}

--- a/k6/3-rampUp.js
+++ b/k6/3-rampUp.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+    stages: [
+        { duration: '10s', target: 2 },
+        { duration: '10s', target: 4 },
+        { duration: '10s', target: 6 },
+        { duration: '10s', target: 8 },
+        { duration: '10s', target: 10 },
+        { duration: '10s', target: 12 },
+        { duration: '10s', target: 14 },
+        { duration: '10s', target: 16 },
+        { duration: '10s', target: 18 },
+        { duration: '10s', target: 20 },
+
+    ],
+};
+
+export default function () {
+    const params = {
+        headers: {
+            'x-api-key': 'abc',
+        },
+    };
+
+    const res = http.get('http://localhost:8000/fetch_data?block_start=18530000&block_end=18530100', params);
+    check(res, { 'status was 200': (r) => r.status == 200 });
+    sleep(1);
+}

--- a/k6/test1.txt
+++ b/k6/test1.txt
@@ -1,0 +1,264 @@
+For the APi itself, 
+Test 1: Increase concurrent users
+
+Summary---------------
+
+| Statistic              | 1 VU        | 10 VUs       | 100 VUs      | 1000 VUs     |
+|------------------------|-------------|--------------|--------------|--------------|
+| data_received (avg)    | 5.4 kB      | 54 kB        | 535 kB       | 682 kB       |
+| data_sent (avg)        | 2.9 kB      | 29 kB        | 288 kB       | 508 kB       |
+| http_req_blocked (avg) | 15.75µs     | 18.25µs      | 43.91µs      | 9.21ms       |
+| http_req_connecting (av| 4.8µs       | 3.49µs       | 33.93µs      | 8.82ms       |
+| http_req_duration (avg)| 1.93ms      | 3.78ms       | 42.57ms      | 1.48s        |
+| http_req_failed (%)    | 0.00%       | 0.00%        | 0.00%        | 0.00%        |
+| http_req_receiving (avg| 116.51µs    | 104.13µs     | 61.25µs      | 37.94µs      |
+| http_req_sending (avg) | 38.9µs      | 35.13µs      | 29.14µs      | 1.34ms       |
+| http_req_waiting (avg) | 1.77ms      | 3.64ms       | 42.48ms      | 1.48s        |
+| http_reqs (avg)        | 20          | 200          | 1975         | 2517         |
+| iteration_duration (avg)| 1s         | 1s           | 1.04s        | 2.49s        |
+| iterations (avg)       | 20          | 200          | 1975         | 2517         |
+
+blocks: http://localhost:8000/fetch_data?block_start=18530000&block_end=18530100
+Test duration: 20s
+
+-----------------------------------------------------------
+
+
+a2k@A2K:~/dev/rust/api2/k6$ k6 run ali.js 
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ali.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
+           * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
+
+
+     data_received..................: 271 B 270 B/s
+     data_sent......................: 146 B 146 B/s
+     http_req_blocked...............: avg=155.33µs min=155.33µs med=155.33µs max=155.33µs p(90)=155.33µs p(95)=155.33µs
+     http_req_connecting............: avg=96.49µs  min=96.49µs  med=96.49µs  max=96.49µs  p(90)=96.49µs  p(95)=96.49µs 
+     http_req_duration..............: avg=769.38µs min=769.38µs med=769.38µs max=769.38µs p(90)=769.38µs p(95)=769.38µs
+       { expected_response:true }...: avg=769.38µs min=769.38µs med=769.38µs max=769.38µs p(90)=769.38µs p(95)=769.38µs
+     http_req_failed................: 0.00% ✓ 0        ✗ 1  
+     http_req_receiving.............: avg=39.41µs  min=39.41µs  med=39.41µs  max=39.41µs  p(90)=39.41µs  p(95)=39.41µs 
+     http_req_sending...............: avg=67.53µs  min=67.53µs  med=67.53µs  max=67.53µs  p(90)=67.53µs  p(95)=67.53µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=662.43µs min=662.43µs med=662.43µs max=662.43µs p(90)=662.43µs p(95)=662.43µs
+     http_reqs......................: 1     0.997663/s
+     iteration_duration.............: avg=1s       min=1s       med=1s       max=1s       p(90)=1s       p(95)=1s      
+     iterations.....................: 1     0.997663/s
+     vus............................: 1     min=1      max=1
+     vus_max........................: 1     min=1      max=1
+
+
+1 VU, 20 seconds ---------------------------------------------------------------------------
+
+a2k@A2K:~/dev/rust/api2/k6$ k6 run ali.js --duration 20s
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ali.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 50s max duration (incl. graceful stop):
+           * default: 1 looping VUs for 20s (gracefulStop: 30s)
+
+
+     data_received..................: 5.4 kB 270 B/s
+     data_sent......................: 2.9 kB 146 B/s
+     http_req_blocked...............: avg=15.75µs  min=2.91µs   med=8.79µs   max=157.24µs p(90)=17.11µs p(95)=27.12µs 
+     http_req_connecting............: avg=4.8µs    min=0s       med=0s       max=96.13µs  p(90)=0s      p(95)=4.8µs   
+     http_req_duration..............: avg=1.93ms   min=796.87µs med=2.21ms   max=3.79ms   p(90)=2.65ms  p(95)=2.86ms  
+       { expected_response:true }...: avg=1.93ms   min=796.87µs med=2.21ms   max=3.79ms   p(90)=2.65ms  p(95)=2.86ms  
+     http_req_failed................: 0.00%  ✓ 0        ✗ 20 
+     http_req_receiving.............: avg=116.51µs min=44.05µs  med=110.76µs max=194.56µs p(90)=171.2µs p(95)=182.55µs
+     http_req_sending...............: avg=38.9µs   min=13.77µs  med=40.37µs  max=74.87µs  p(90)=54.41µs p(95)=63.48µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s       p(90)=0s      p(95)=0s      
+     http_req_waiting...............: avg=1.77ms   min=714.9µs  med=2.08ms   max=3.54ms   p(90)=2.48ms  p(95)=2.68ms  
+     http_reqs......................: 20     0.997238/s
+     iteration_duration.............: avg=1s       min=1s       med=1s       max=1s       p(90)=1s      p(95)=1s      
+     iterations.....................: 20     0.997238/s
+     vus............................: 1      min=1      max=1
+     vus_max........................: 1      min=1      max=1
+
+
+running (20.1s), 0/1 VUs, 20 complete and 0 interrupted iterations
+default ✓ [======================================] 1 VUs  20s
+a2k@A2K:~/dev/rust/api2/k6$ 
+
+
+10 VUs, single request -------------------------------------------------------------
+a2k@A2K:~/dev/rust/api2/k6$ k6 run ali.js --vus 10
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+WARN[0000] the `vus=10` option will be ignored, it only works in conjunction with `iterations`, `duration`, or `stages` 
+  execution: local
+     script: ali.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
+           * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
+
+
+     data_received..................: 271 B 270 B/s
+     data_sent......................: 146 B 146 B/s
+     http_req_blocked...............: avg=104.84µs min=104.84µs med=104.84µs max=104.84µs p(90)=104.84µs p(95)=104.84µs
+     http_req_connecting............: avg=55.44µs  min=55.44µs  med=55.44µs  max=55.44µs  p(90)=55.44µs  p(95)=55.44µs 
+     http_req_duration..............: avg=1.62ms   min=1.62ms   med=1.62ms   max=1.62ms   p(90)=1.62ms   p(95)=1.62ms  
+       { expected_response:true }...: avg=1.62ms   min=1.62ms   med=1.62ms   max=1.62ms   p(90)=1.62ms   p(95)=1.62ms  
+     http_req_failed................: 0.00% ✓ 0        ✗ 1  
+     http_req_receiving.............: avg=47.06µs  min=47.06µs  med=47.06µs  max=47.06µs  p(90)=47.06µs  p(95)=47.06µs 
+     http_req_sending...............: avg=36.66µs  min=36.66µs  med=36.66µs  max=36.66µs  p(90)=36.66µs  p(95)=36.66µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=1.54ms   min=1.54ms   med=1.54ms   max=1.54ms   p(90)=1.54ms   p(95)=1.54ms  
+     http_reqs......................: 1     0.996912/s
+     iteration_duration.............: avg=1s       min=1s       med=1s       max=1s       p(90)=1s       p(95)=1s      
+     iterations.....................: 1     0.996912/s
+     vus............................: 1     min=1      max=1
+     vus_max........................: 1     min=1      max=1
+
+
+running (00m01.0s), 0/1 VUs, 1 complete and 0 interrupted iterations
+default ✓ [======================================] 1 VUs  00m01.0s/10m0s  1/1 iters, 1 per VU
+a2k@A2K:~/dev/rust/api2/k6$ 
+
+
+
+10 VUs, 20s ----------------------------------------------------------------------
+
+
+a2k@A2K:~/dev/rust/api2/k6$ k6 run ali.js --duration 20s --vus 10
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ali.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 10 max VUs, 50s max duration (incl. graceful stop):
+           * default: 10 looping VUs for 20s (gracefulStop: 30s)
+
+
+     data_received..................: 54 kB 2.7 kB/s
+     data_sent......................: 29 kB 1.5 kB/s
+     http_req_blocked...............: avg=18.25µs  min=1.93µs   med=7.96µs  max=957.53µs p(90)=15.77µs  p(95)=100.23µs
+     http_req_connecting............: avg=3.49µs   min=0s       med=0s      max=100.58µs p(90)=0s       p(95)=2.18µs  
+     http_req_duration..............: avg=3.78ms   min=499.99µs med=2.18ms  max=35.22ms  p(90)=8.33ms   p(95)=12.11ms 
+       { expected_response:true }...: avg=3.78ms   min=499.99µs med=2.18ms  max=35.22ms  p(90)=8.33ms   p(95)=12.11ms 
+     http_req_failed................: 0.00% ✓ 0        ✗ 200 
+     http_req_receiving.............: avg=104.13µs min=16.34µs  med=93.84µs max=643.78µs p(90)=167.15µs p(95)=193.81µs
+     http_req_sending...............: avg=35.13µs  min=8.18µs   med=34.28µs max=120.36µs p(90)=56.05µs  p(95)=63.18µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=3.64ms   min=438.9µs  med=1.99ms  max=35.07ms  p(90)=8.24ms   p(95)=11.98ms 
+     http_reqs......................: 200   9.940872/s
+     iteration_duration.............: avg=1s       min=1s       med=1s      max=1.03s    p(90)=1s       p(95)=1.01s   
+     iterations.....................: 200   9.940872/s
+     vus............................: 10    min=10     max=10
+     vus_max........................: 10    min=10     max=10
+
+
+running (20.1s), 00/10 VUs, 200 complete and 0 interrupted iterations
+default ✓ [======================================] 10 VUs  20s
+a2k@A2K:~/dev/rust/api2/k6$ 
+
+
+100 VUs, 20s --------------------------------------------------------
+
+a2k@A2K:~/dev/rust/api2/k6$ k6 run ali.js --vus 100 --duration 20s
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ali.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 100 max VUs, 50s max duration (incl. graceful stop):
+           * default: 100 looping VUs for 20s (gracefulStop: 30s)
+
+
+     data_received..................: 535 kB 26 kB/s
+     data_sent......................: 288 kB 14 kB/s
+     http_req_blocked...............: avg=43.91µs min=1.05µs   med=3.48µs  max=1.38ms   p(90)=11.21µs  p(95)=92.38µs 
+     http_req_connecting............: avg=33.93µs min=0s       med=0s      max=1.17ms   p(90)=0s       p(95)=36.57µs 
+     http_req_duration..............: avg=42.57ms min=406.26µs med=19.85ms max=370.29ms p(90)=113.24ms p(95)=169.11ms
+       { expected_response:true }...: avg=42.57ms min=406.26µs med=19.85ms max=370.29ms p(90)=113.24ms p(95)=169.11ms
+     http_req_failed................: 0.00%  ✓ 0         ✗ 1975 
+     http_req_receiving.............: avg=61.25µs min=12.19µs  med=39.61µs max=2.72ms   p(90)=111.14µs p(95)=154.99µs
+     http_req_sending...............: avg=29.14µs min=4.34µs   med=14.2µs  max=385.83µs p(90)=51.66µs  p(95)=99.82µs 
+     http_req_tls_handshaking.......: avg=0s      min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=42.48ms min=372.03µs med=19.64ms max=370.21ms p(90)=113.2ms  p(95)=169.08ms
+     http_reqs......................: 1975   94.085789/s
+     iteration_duration.............: avg=1.04s   min=1s       med=1.02s   max=1.37s    p(90)=1.11s    p(95)=1.16s   
+     iterations.....................: 1975   94.085789/s
+     vus............................: 100    min=100     max=100
+     vus_max........................: 100    min=100     max=100
+
+
+running (21.0s), 000/100 VUs, 1975 complete and 0 interrupted iterations
+default ✓ [======================================] 100 VUs  20s
+a2k@A2K:~/dev/rust/api2/k6$ 
+
+
+1000 VUs, 20s (significantly slower) ------------------------------------------------------------
+a2k@A2K:~/dev/rust/api2/k6$ k6 run ali.js --vus 1000 --duration 20s
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ali.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1000 max VUs, 50s max duration (incl. graceful stop):
+           * default: 1000 looping VUs for 20s (gracefulStop: 30s)
+
+
+     data_received..................: 682 kB 14 kB/s
+     data_sent......................: 508 kB 10 kB/s
+     http_req_blocked...............: avg=9.21ms  min=965ns    med=3.28µs   max=92.8ms  p(90)=32.8ms p(95)=50.37ms
+     http_req_connecting............: avg=8.82ms  min=0s       med=0s       max=84.53ms p(90)=31.6ms p(95)=50.03ms
+     http_req_duration..............: avg=1.48s   min=661.19µs med=309.55ms max=17.18s  p(90)=5.46s  p(95)=7.84s  
+       { expected_response:true }...: avg=1.48s   min=661.19µs med=309.55ms max=17.18s  p(90)=5.46s  p(95)=7.84s  
+     http_req_failed................: 0.00%  ✓ 0         ✗ 2517  
+     http_req_receiving.............: avg=37.94µs min=9.23µs   med=30.05µs  max=2.06ms  p(90)=60µs   p(95)=75.54µs
+     http_req_sending...............: avg=1.34ms  min=3.77µs   med=12.35µs  max=65.79ms p(90)=2.57ms p(95)=4.12ms 
+     http_req_tls_handshaking.......: avg=0s      min=0s       med=0s       max=0s      p(90)=0s     p(95)=0s     
+     http_req_waiting...............: avg=1.48s   min=626.87µs med=308.05ms max=17.18s  p(90)=5.46s  p(95)=7.84s  
+     http_reqs......................: 2517   50.328338/s
+     iteration_duration.............: avg=2.49s   min=1s       med=1.31s    max=18.18s  p(90)=6.46s  p(95)=8.84s  
+     iterations.....................: 2517   50.328338/s
+     vus............................: 961    min=961     max=1000
+     vus_max........................: 1000   min=1000    max=1000
+
+
+running (50.0s), 0000/1000 VUs, 2517 complete and 961 interrupted iterations
+default ✓ [======================================] 1000 VUs  20s
+

--- a/k6/test1b.txt
+++ b/k6/test1b.txt
@@ -1,0 +1,120 @@
+no issues in the back
+a2k@A2K:~/dev/rust/api2/k6$ k6 run 1-concurrentUsers.js --duration 5s
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: 1-concurrentUsers.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 35s max duration (incl. graceful stop):
+           * default: 1 looping VUs for 5s (gracefulStop: 30s)
+
+
+     data_received..................: 1.4 kB 270 B/s
+     data_sent......................: 730 B  146 B/s
+     http_req_blocked...............: avg=38.21µs min=9.43µs   med=12.04µs  max=145.34µs p(90)=92.54µs  p(95)=118.94µs
+     http_req_connecting............: avg=19.1µs  min=0s       med=0s       max=95.5µs   p(90)=57.3µs   p(95)=76.4µs  
+     http_req_duration..............: avg=2.08ms  min=773.9µs  med=2.39ms   max=2.81ms   p(90)=2.65ms   p(95)=2.73ms  
+       { expected_response:true }...: avg=2.08ms  min=773.9µs  med=2.39ms   max=2.81ms   p(90)=2.65ms   p(95)=2.73ms  
+     http_req_failed................: 0.00%  ✓ 0        ✗ 5  
+     http_req_receiving.............: avg=138.3µs min=43.6µs   med=172.17µs max=192.01µs p(90)=186.21µs p(95)=189.11µs
+     http_req_sending...............: avg=50.49µs min=34.2µs   med=49.61µs  max=65.87µs  p(90)=60.96µs  p(95)=63.41µs 
+     http_req_tls_handshaking.......: avg=0s      min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=1.89ms  min=680.68µs med=2.16ms   max=2.58ms   p(90)=2.42ms   p(95)=2.5ms   
+     http_reqs......................: 5      0.996756/s
+     iteration_duration.............: avg=1s      min=1s       med=1s       max=1s       p(90)=1s       p(95)=1s      
+     iterations.....................: 5      0.996756/s
+     vus............................: 1      min=1      max=1
+     vus_max........................: 1      min=1      max=1
+
+
+
+10 users-----------------------------------------------------------------------------
+backend takes significnatly longer to finish tasks
+
+a2k@A2K:~/dev/rust/api2/k6$ k6 run 1-concurrentUsers.js --duration 5s --vus 10
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: 1-concurrentUsers.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 10 max VUs, 35s max duration (incl. graceful stop):
+           * default: 10 looping VUs for 5s (gracefulStop: 30s)
+
+
+     data_received..................: 14 kB  2.7 kB/s
+     data_sent......................: 7.3 kB 1.4 kB/s
+     http_req_blocked...............: avg=36.03µs min=2.3µs    med=8.25µs  max=188.6µs  p(90)=145.3µs  p(95)=174.39µs
+     http_req_connecting............: avg=18.16µs min=0s       med=0s      max=140.74µs p(90)=85.04µs  p(95)=111.78µs
+     http_req_duration..............: avg=6.57ms  min=601.96µs med=1.62ms  max=27.26ms  p(90)=22.52ms  p(95)=26.52ms 
+       { expected_response:true }...: avg=6.57ms  min=601.96µs med=1.62ms  max=27.26ms  p(90)=22.52ms  p(95)=26.52ms 
+     http_req_failed................: 0.00%  ✓ 0        ✗ 50  
+     http_req_receiving.............: avg=87.84µs min=14.66µs  med=54.56µs max=485.75µs p(90)=150.34µs p(95)=183.08µs
+     http_req_sending...............: avg=32.45µs min=8.92µs   med=33.28µs max=88.39µs  p(90)=49.12µs  p(95)=55.99µs 
+     http_req_tls_handshaking.......: avg=0s      min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=6.45ms  min=543.45µs med=1.57ms  max=27.08ms  p(90)=22.31ms  p(95)=26.31ms 
+     http_reqs......................: 50     9.892765/s
+     iteration_duration.............: avg=1s      min=1s       med=1s      max=1.02s    p(90)=1.02s    p(95)=1.02s   
+     iterations.....................: 50     9.892765/s
+     vus............................: 10     min=10     max=10
+     vus_max........................: 10     min=10     max=10
+
+
+running (05.1s), 00/10 VUs, 50 complete and 0 interrupted iterations
+
+
+100 users -----------------------------------------------
+backend sees many errors:
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: dns error: Device or resource busy (os error 16)
+(seems like too many to handle)
+
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: Connection reset by peer (os error 104)
+(seems like alchemy rate limit)
+
+a2k@A2K:~/dev/rust/api2/k6$ k6 run 1-concurrentUsers.js --duration 5s --vus 100
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: 1-concurrentUsers.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 100 max VUs, 35s max duration (incl. graceful stop):
+           * default: 100 looping VUs for 5s (gracefulStop: 30s)
+
+
+     data_received..................: 136 kB 22 kB/s
+     data_sent......................: 73 kB  12 kB/s
+     http_req_blocked...............: avg=77.3µs   min=1.33µs   med=5.53µs  max=1.68ms   p(90)=229.2µs  p(95)=448.7µs 
+     http_req_connecting............: avg=38.74µs  min=0s       med=0s      max=699.65µs p(90)=131.33µs p(95)=299.89µs
+     http_req_duration..............: avg=158.73ms min=581.57µs med=55.04ms max=849.2ms  p(90)=502.99ms p(95)=624.73ms
+       { expected_response:true }...: avg=158.73ms min=581.57µs med=55.04ms max=849.2ms  p(90)=502.99ms p(95)=624.73ms
+     http_req_failed................: 0.00%  ✓ 0        ✗ 500  
+     http_req_receiving.............: avg=53.36µs  min=16.48µs  med=43.83µs max=264.44µs p(90)=99.04µs  p(95)=129.31µs
+     http_req_sending...............: avg=49.43µs  min=5.08µs   med=19.88µs max=798.24µs p(90)=134.65µs p(95)=296.63µs
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=158.62ms min=521.23µs med=54.96ms max=849.13ms p(90)=502.86ms p(95)=624.62ms
+     http_reqs......................: 500    79.53618/s
+     iteration_duration.............: avg=1.15s    min=1s       med=1.05s   max=1.84s    p(90)=1.5s     p(95)=1.62s   
+     iterations.....................: 500    79.53618/s
+     vus............................: 35     min=35     max=100
+     vus_max........................: 100    min=100    max=100
+
+
+running (06.3s), 000/100 VUs, 500 complete and 0 interrupted iterations
+default ✓ [======================================] 100 VUs  5s

--- a/k6/test2.txt
+++ b/k6/test2.txt
@@ -1,0 +1,147 @@
+a2k@A2K:~/dev/rust/api2/k6$ k6 run 2-moreBlocks.js --duration 10s
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: 2-moreBlocks.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 40s max duration (incl. graceful stop):
+           * default: 1 looping VUs for 10s (gracefulStop: 30s)
+
+
+     data_received..................: 2.7 kB 270 B/s
+     data_sent......................: 1.5 kB 146 B/s
+     http_req_blocked...............: avg=26.2µs   min=3.08µs   med=10.4µs   max=191.07µs p(90)=30.19µs  p(95)=110.63µs
+     http_req_connecting............: avg=9.87µs   min=0s       med=0s       max=98.78µs  p(90)=9.87µs   p(95)=54.32µs 
+     http_req_duration..............: avg=1.88ms   min=624.24µs med=1.67ms   max=3.57ms   p(90)=3.18ms   p(95)=3.37ms  
+       { expected_response:true }...: avg=1.88ms   min=624.24µs med=1.67ms   max=3.57ms   p(90)=3.18ms   p(95)=3.37ms  
+     http_req_failed................: 0.00%  ✓ 0        ✗ 10 
+     http_req_receiving.............: avg=114.18µs min=44.72µs  med=107.34µs max=181.67µs p(90)=180.16µs p(95)=180.92µs
+     http_req_sending...............: avg=38.56µs  min=10.11µs  med=44.59µs  max=81.63µs  p(90)=61.84µs  p(95)=71.73µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=1.73ms   min=565.5µs  med=1.54ms   max=3.34ms   p(90)=2.95ms   p(95)=3.15ms  
+     http_reqs......................: 10     0.997389/s
+     iteration_duration.............: avg=1s       min=1s       med=1s       max=1s       p(90)=1s       p(95)=1s      
+     iterations.....................: 10     0.997389/s
+     vus............................: 1      min=1      max=1
+     vus_max........................: 1      min=1      max=1
+
+
+running (10.0s), 0/1 VUs, 10 complete and 0 interrupted iterations
+default ✓ [======================================] 1 VUs  10s
+
+-----------------
+try http://localhost:8000/fetch_data?block_start=18530000&block_end=18531000
+1k blocks
+
+works, but getting rate limited
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: Connection reset by peer (os error 104)
+
+tasks initiation not an issue:
+a2k@A2K:~/dev/rust/api2/k6$ k6 run 2-moreBlocks.js --duration 10s
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: 2-moreBlocks.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 40s max duration (incl. graceful stop):
+           * default: 1 looping VUs for 10s (gracefulStop: 30s)
+
+
+     data_received..................: 2.7 kB 271 B/s
+     data_sent......................: 1.5 kB 146 B/s
+     http_req_blocked...............: avg=15.97µs  min=2.72µs   med=3.88µs   max=120.13µs p(90)=20.86µs  p(95)=70.49µs 
+     http_req_connecting............: avg=7.13µs   min=0s       med=0s       max=71.37µs  p(90)=7.13µs   p(95)=39.25µs 
+     http_req_duration..............: avg=861.33µs min=542.22µs med=806.77µs max=1.52ms   p(90)=1.1ms    p(95)=1.31ms  
+       { expected_response:true }...: avg=861.33µs min=542.22µs med=806.77µs max=1.52ms   p(90)=1.1ms    p(95)=1.31ms  
+     http_req_failed................: 0.00%  ✓ 0        ✗ 10 
+     http_req_receiving.............: avg=66.42µs  min=36.16µs  med=45.29µs  max=135.59µs p(90)=128.67µs p(95)=132.13µs
+     http_req_sending...............: avg=26.42µs  min=11.42µs  med=17.64µs  max=72.4µs   p(90)=45.3µs   p(95)=58.85µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=768.48µs min=488.8µs  med=728.53µs max=1.35ms   p(90)=969.58µs p(95)=1.16ms  
+     http_reqs......................: 10     0.998265/s
+     iteration_duration.............: avg=1s       min=1s       med=1s       max=1s       p(90)=1s       p(95)=1s      
+     iterations.....................: 10     0.998265/s
+     vus............................: 1      min=1      max=1
+     vus_max........................: 1      min=1      max=1
+
+
+
+-------------------------------------------
+
+Try http://localhost:8000/fetch_data?block_start=18530000&block_end=18535000
+5k blocks
+
+start getting issues:
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: tcp open error: Too many open files (os error 24)
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: dns error: Device or resource busy (os error 16)
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: Connection reset by peer (os error 104)
+
+a2k@A2K:~/dev/rust/api2/k6$ k6 run 2-moreBlocks.js --duration 10s
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: 2-moreBlocks.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 1 max VUs, 40s max duration (incl. graceful stop):
+           * default: 1 looping VUs for 10s (gracefulStop: 30s)
+
+
+     data_received..................: 2.7 kB 264 B/s
+     data_sent......................: 1.5 kB 142 B/s
+     http_req_blocked...............: avg=114.37µs min=3.88µs   med=7.72µs  max=641.15µs p(90)=467.7µs  p(95)=554.43µs
+     http_req_connecting............: avg=13.48µs  min=0s       med=0s      max=134.81µs p(90)=13.48µs  p(95)=74.14µs 
+     http_req_duration..............: avg=24.7ms   min=799.28µs med=2.23ms  max=155.15ms p(90)=84.04ms  p(95)=119.6ms 
+       { expected_response:true }...: avg=24.7ms   min=799.28µs med=2.23ms  max=155.15ms p(90)=84.04ms  p(95)=119.6ms 
+     http_req_failed................: 0.00%  ✓ 0        ✗ 10 
+     http_req_receiving.............: avg=72.57µs  min=41.06µs  med=56.69µs max=133.04µs p(90)=121.93µs p(95)=127.49µs
+     http_req_sending...............: avg=29.39µs  min=16.91µs  med=31.5µs  max=39.53µs  p(90)=39.24µs  p(95)=39.39µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
+     http_req_waiting...............: avg=24.6ms   min=721.35µs med=2.15ms  max=155.08ms p(90)=83.98ms  p(95)=119.53ms
+     http_reqs......................: 10     0.974925/s
+     iteration_duration.............: avg=1.02s    min=1s       med=1s      max=1.15s    p(90)=1.08s    p(95)=1.12s   
+     iterations.....................: 10     0.974925/s
+     vus............................: 1      min=1      max=1
+     vus_max........................: 1      min=1      max=1
+
+
+-------------------------
+
+rate limit issue: Will need to set a max number of active tasks/workers using the reqwest client
+each task must wait until they get a turn. 
+Maybe use mutex?
+
+same with the other two issues:
+-tcp open error: Too many open files (os error 24)
+-error trying to connect: dns error: Device or resource busy (os error 16)
+
+attempts to do API calls should be restricted (eg. 10 active at a time)
+
+and also, some sort of cache. if request includes a certain block range, obtain from cache first, before caling API. 
+or use a db. check first. if not available, obtain via api
+
+
+
+
+-------------------------------------------------
+
+
+
+

--- a/k6/test3.txt
+++ b/k6/test3.txt
@@ -1,0 +1,8 @@
+Gradually ramp up number of users for constantly active
+
+At about 9 VUs, start to see errors.
+Same kind (device or os, error trying to connect)
+
+
+-need to limit number of open connections? tasks?
+-need to limit number of concurrent API requests

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -68,14 +68,21 @@ pub fn fetch_data(
     map: &State<TaskMap>,
     client: &State<Arc<Client>>,
 ) -> String {
-    let _block_start = block_start.unwrap_or(18277200); // Provide default value here
-    let _block_end = block_end.unwrap_or(18277300); // Provide default value here
+    // println!("\n***RAW block_start: {:?} \n", block_start);
+    // println!("\n***RAW block_end: {:?} \n", block_end);
+
+    //     let _block_start = block_start.unwrap_or(18277200); // Provide default value here
+    //     let _block_end = block_end.unwrap_or(18277300); // Provide default value here
+
+    let _block_start = block_start.unwrap_or_else(|| 182770000);
+    let _block_end = block_end.unwrap_or_else(|| 182770010);
+
     let _contract_address = contract_address
         .unwrap_or_else(|| "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string()); // Provide default value here
 
-    println!("block_start: {}", _block_start);
-    println!("block_end: {}", _block_end);
-    println!("contract_address: {}", _contract_address);
+    // println!("block_start: {}", _block_start);
+    // println!("block_end: {}", _block_end);
+    // println!("contract_address: {}", _contract_address);
 
     let task_id = uuid::Uuid::new_v4().to_string();
 
@@ -162,10 +169,10 @@ pub async fn get_chain_data(
         let batchsize = 3;
         let current_end = std::cmp::min(current_start + (batchsize - 1), end_block);
 
-        println!(
-            "spawning task for blocks {} to {}",
-            current_start, current_end
-        );
+        // println!(
+        //     "spawning task for blocks {} to {}",
+        //     current_start, current_end
+        // );
 
         let client_clone = client.clone();
 


### PR DESCRIPTION
3 tests:

1. simple test on concurrent users. 
For a single request, no problem. API itself has no problem generating tasks and returning ID. Problems in returning an ID only happen after 1000 users: significnatly slower response. However, in the back, the API itself sees connection issues already with 100 users.

2. increasing block range: 100 blocks, no problem. 1000 blocks, see the same connection issues

3. gradual ramp up: continuously repeat calls, but gradually increase users. at 9, already seeing the connection issues.


These are the connection issues:

error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: Connection reset by peer (os error 104)

error trying to connect: dns error: Device or resource busy (os error 16)

error trying to connect: Connection reset by peer (os error 104)


Should limit concurrent connections and tasks
