### PR TITLE
Cacher

### DIFF
--- a/k6/test1b.txt
+++ b/k6/test1b.txt
@@ -76,10 +76,12 @@ running (05.1s), 00/10 VUs, 50 complete and 0 interrupted iterations
 
 100 users -----------------------------------------------
 backend sees many errors:
-Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: dns error: Device or resource busy (os error 16)
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): 
+error trying to connect: dns error: Device or resource busy (os error 16)
 (seems like too many to handle)
 
-Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): error trying to connect: Connection reset by peer (os error 104)
+Error fetching logs: error sending request for url (https://eth-mainnet.g.alchemy.com/v2/84GnvlKF-rAfskHdmivKpipIoSLF033I): 
+error trying to connect: Connection reset by peer (os error 104)
 (seems like alchemy rate limit)
 
 a2k@A2K:~/dev/rust/api2/k6$ k6 run 1-concurrentUsers.js --duration 5s --vus 100

--- a/k6/test3.txt
+++ b/k6/test3.txt
@@ -6,3 +6,4 @@ Same kind (device or os, error trying to connect)
 
 -need to limit number of open connections? tasks?
 -need to limit number of concurrent API requests
+

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,5 @@
+use std::collections::HashMap;
+
+struct Cacher {
+    map: HashMap<String, String>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,12 @@ extern crate rocket;
 use reqwest;
 
 mod routes;
-use routes::{check_data, fetch_data, hello_world};
+use routes::{check_cache, check_data, fetch_data, hello_world};
 use std::sync::Arc;
 
 mod types;
 use dotenv::dotenv;
-use types::TaskMap;
+use types::{CacheMap, TaskMap};
 
 #[launch]
 fn rocket() -> _ {
@@ -21,5 +21,9 @@ fn rocket() -> _ {
     rocket::build()
         .manage(TaskMap::default())
         .manage(reqwestClient)
-        .mount("/", routes![hello_world, fetch_data, check_data])
+        .manage(CacheMap::default())
+        .mount(
+            "/",
+            routes![hello_world, fetch_data, check_data, check_cache],
+        )
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 // use crate::chain_data::get_chain_data;
 
-use crate::types::{Log, Response, TaskData, TaskMap, TaskStatus};
+use crate::types::{CacheMap, Log, Response, TaskData, TaskMap, TaskStatus};
+
+use std::collections::HashMap;
 
 #[derive(Serialize)]
 pub struct GenericResponse {
@@ -62,11 +64,12 @@ pub fn hello_world(_api_key: ApiKey) -> Result<Json<GenericResponse>, Status> {
 #[get("/fetch_data?<block_start>&<block_end>&<contract_address>")]
 pub fn fetch_data(
     _api_key: ApiKey,
-    block_start: Option<u64>,         // Optional query parameter
-    block_end: Option<u64>,           // Optional query parameter
-    contract_address: Option<String>, // Optional query parameter
+    block_start: Option<u64>,
+    block_end: Option<u64>,
+    contract_address: Option<String>,
     map: &State<TaskMap>,
     client: &State<Arc<Client>>,
+    cache: &State<CacheMap>,
 ) -> String {
     // println!("\n***RAW block_start: {:?} \n", block_start);
     // println!("\n***RAW block_end: {:?} \n", block_end);
@@ -90,14 +93,17 @@ pub fn fetch_data(
     let task_id3 = task_id.clone();
 
     let client_clone = client.inner().clone();
+    let cache_clone = cache.inner().clone();
 
     let map = map.inner().clone();
+
     tokio::spawn(async move {
         let data = TaskData {
             status: TaskStatus::InProgress,
             data: None,
         };
-        let res = match map.lock() {
+
+        match map.lock() {
             Ok(mut m) => {
                 println!("Got lock!");
                 m.insert(task_id2, data);
@@ -109,17 +115,23 @@ pub fn fetch_data(
 
         // .unwrap().insert(task_id2, data);
 
-        let chain_data: Result<Vec<Log>, Box<dyn Error>> =
-            get_chain_data(_block_start, _block_end, _contract_address, client_clone).await;
+        let chain_data: Result<Vec<Log>, Box<dyn Error>> = get_chain_data(
+            _block_start,
+            _block_end,
+            _contract_address,
+            client_clone,
+            cache_clone,
+        )
+        .await;
         // println!("task_id2: {}", task_id2);
 
-        let response = match map.lock() {
+        match map.lock() {
             Ok(mut m) => {
                 println!("Got lock! to write data");
                 let task_entry = m.get_mut(&task_id3).unwrap();
                 task_entry.status = TaskStatus::Completed;
                 // data.data = Some(chain_data);
-                match (chain_data) {
+                match chain_data {
                     Ok(data) => {
                         task_entry.data = Some(data);
                         println!("task_entry data saved");
@@ -156,6 +168,7 @@ pub async fn get_chain_data(
     end_block: u64,
     target_address: String,
     client: Arc<Client>,
+    cache: CacheMap,
 ) -> Result<Vec<Log>, Box<dyn Error>> {
     println!("Starting get_chain_data");
 
@@ -175,11 +188,13 @@ pub async fn get_chain_data(
         // );
 
         let client_clone = client.clone();
+        let cache_clone = Arc::clone(&cache);
 
         let handle = tokio::task::spawn(fetch_logs_from_blocks(
             block_to_hex(current_start).to_string(),
             block_to_hex(current_end).to_string(),
             client_clone,
+            cache_clone,
         ));
         handles.push(handle);
 
@@ -220,6 +235,7 @@ async fn fetch_logs_from_blocks(
     start_block: String,
     end_block: String,
     client: Arc<Client>,
+    cache: CacheMap,
 ) -> Result<Vec<Log>, ReqwestError> {
     let payload = serde_json::json!({
         "jsonrpc": "2.0",
@@ -231,10 +247,6 @@ async fn fetch_logs_from_blocks(
         }]
     });
 
-    // TODO: Check if these blocks exist in cache.
-    // if so, return Vec<Log> from cache.
-    // if not, continue below and add them to cache. return cache value.
-
     let infura_url = env::var("INFURA_URL").expect("INFURA_URL must be set");
     let res: Response = client
         .post(&infura_url)
@@ -244,9 +256,51 @@ async fn fetch_logs_from_blocks(
         .json()
         .await?;
 
+    // put results into cache hashmap
+    let logs = res.result.clone();
+    let mut grouped_logs: HashMap<String, Vec<Log>> = HashMap::new();
+
+    for log in logs {
+        grouped_logs
+            .entry(log.blockNumber.clone())
+            .or_insert_with(Vec::new)
+            .push(log);
+    }
+
+    for (block_number, log_group) in grouped_logs {
+        cache.lock().unwrap().insert(block_number, log_group);
+    }
+
     Ok(res.result)
 }
 
 fn block_to_hex(block: u64) -> String {
     format!("0x{:x}", block)
+}
+
+#[get("/check_cache?<block_number>")]
+pub fn check_cache(
+    block_number: String,
+    cache: &State<CacheMap>,
+) -> Result<Json<Vec<Log>>, Status> {
+    print!("Checking cache...");
+    println!("block_number: {}", block_number);
+
+    let block_number_hex = block_to_hex(block_number.parse::<u64>().unwrap());
+
+    let cache_map = cache.inner().lock().unwrap();
+    let keys: Vec<_> = cache_map.keys().cloned().collect();
+    // drop(cache_map);
+    let keys_str = keys.join(", ");
+    println!("Cache keys: {}", keys_str);
+
+    // print!("cache_map: {:?}", cache_map);
+
+    match cache_map.get(&block_number_hex) {
+        Some(logs) => Ok(Json(logs.clone())),
+        None => {
+            println!("No logs found in cache");
+            Err(Status::NotFound)
+        }
+    }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -231,9 +231,10 @@ async fn fetch_logs_from_blocks(
         }]
     });
 
-    // dotenv().ok();
+    // TODO: Check if these blocks exist in cache.
+    // if so, return Vec<Log> from cache.
+    // if not, continue below and add them to cache. return cache value.
 
-    // let client = reqwest::Client::new();
     let infura_url = env::var("INFURA_URL").expect("INFURA_URL must be set");
     let res: Response = client
         .post(&infura_url)

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 pub type TaskMap = Arc<Mutex<HashMap<String, TaskData>>>;
+pub type CacheMap = Arc<Mutex<HashMap<String, Vec<Log>>>>;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum TaskStatus {

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,7 @@ pub struct Log {
     pub address: String,
     pub data: String,
     pub topics: Vec<String>,
+    pub blockNumber: String, //added block number for easier hashmap management
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Using Hashmap as an in-memory cache of log data
Each API call to infura gets 2-3 blocks at a time.
Any new block info gets put into cache hashmap

Before calling API, checks to see if all blocks in block range are in cache
if so, return cached data
if not, fetch new data through api calls
